### PR TITLE
feat: update goreleaser version and improve release process

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,7 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
+
 before:
   hooks:
     # You may remove this if you don't use go modules.

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(BINDIR)/$(BINNAME): $(SRC)
 release:
 	@echo "release ${BIN_NAME} ${VERSION}"
 	autotag
-	goreleaser --parallelism 2 --rm-dist
+	goreleaser release --clean
 
 snapshot:
 	@echo "release ${BIN_NAME} ${SNAPSHOT_VERSION}"


### PR DESCRIPTION
- Set `version: 2` in `.goreleaser.yaml` for compatibility with the latest features.
- Modify the `release` target in the Makefile to use `goreleaser release --clean` for a cleaner release process.